### PR TITLE
Upgrade dependencies to latest

### DIFF
--- a/bert-burn/Cargo.toml
+++ b/bert-burn/Cargo.toml
@@ -20,19 +20,19 @@ safetensors = ["candle-core/default"]
 
 [dependencies]
 # Burn
-burn = { version = "0.17.1", default-features = false, features = ["dataset", "std"] }
-cubecl-runtime = { version = "0.3.0", features = ["channel-mpsc"] } # missing feature flag when burn default-features are off
-candle-core = { version = "0.8.4" }
+burn = { version = "0.18.0", default-features = false, features = ["dataset", "std"] }
+cubecl-runtime = { version = "0.6.0", features = ["channel-mpsc"] } # missing feature flag when burn default-features are off
+candle-core = { version = "0.9.1" }
 # Tokenizer
-tokenizers = { version = "0.15.0", default-features = false, features = [
+tokenizers = { version = "0.21.4-dev.0", default-features = false, features = [
   "onig",
   "http",
 ] }
 derive-new = "0.7.0"
-hf-hub = { version = "0.3.2", features = ["tokio"] }
+hf-hub = { version = "0.4.3", features = ["tokio"] }
 
 # Utils
-serde = { version = "1.0.196", features = ["std", "derive"] }
-libm = "0.2.8"
-serde_json = "1.0.113"
-tokio = "1.35.1"
+serde = { version = "1.0.219", features = ["std", "derive"] }
+libm = "0.2.15"
+serde_json = "1.0.141"
+tokio = "1.47.0"

--- a/llama-burn/Cargo.toml
+++ b/llama-burn/Cargo.toml
@@ -23,33 +23,33 @@ vulkan = ["burn/vulkan"]
 import = ["burn-import"]
 
 [dependencies]
-burn = { version = "0.17.1", default-features = false, features = ["std"] }
-burn-import = { version = "0.17.1", optional = true }
+burn = { version = "0.18.0", default-features = false, features = ["std"] }
+burn-import = { version = "0.18.0", optional = true }
 
-itertools = { version = "0.12.1", default-features = false, features = [
+itertools = { version = "0.14.0", default-features = false, features = [
     "use_alloc",
 ] }
-dirs = { version = "5.0.1", optional = true }
-serde = { version = "1.0.192", default-features = false, features = [
+dirs = { version = "6.0.0", optional = true }
+serde = { version = "1.0.219", default-features = false, features = [
     "derive",
     "alloc",
 ] } # alloc is for no_std, derive is needed
 
 # Tiktoken tokenizer (llama 3)
-tiktoken-rs = { version = "0.5.8", optional = true }
+tiktoken-rs = { version = "0.7.0", optional = true }
 base64 = { version = "0.22.1", optional = true }
-rustc-hash = { version = "1.1.0", optional = true }
+rustc-hash = { version = "2.1.1", optional = true }
 
 # SentencePiece tokenizer (tiny llama / llama 2)
-tokenizers = { version = "0.19.1", default-features = false, features = [
+tokenizers = { version = "0.21.4-dev.0", default-features = false, features = [
     "onig",
 ], optional = true }
 
-rand = { version = "0.8.5", default-features = false, features = [
+rand = { version = "0.9.2", default-features = false, features = [
     "alloc",
     "std_rng",
 ] } # std_rng is for no_std
 
 [dev-dependencies]
-burn = { version = "0.17.1", default-features = false }
-clap = { version = "4.5.4", features = ["derive"] }
+burn = { version = "0.18.0", default-features = false }
+clap = { version = "4.5.41", features = ["derive"] }

--- a/mobilenetv2-burn/Cargo.toml
+++ b/mobilenetv2-burn/Cargo.toml
@@ -12,14 +12,14 @@ pretrained = ["burn/network", "std", "dep:dirs"]
 
 [dependencies]
 # Note: default-features = false is needed to disable std
-burn = { version = "0.17.1" }
-burn-import = { version = "0.17.1" }
-dirs = { version = "5.0.1", optional = true }
-serde = { version = "1.0.192", default-features = false, features = [
+burn = { version = "0.18.0", default-features = false, features = ["std"] }
+burn-import = { version = "0.18.0" }
+dirs = { version = "6.0.0", optional = true }
+serde = { version = "1.0.219", default-features = false, features = [
   "derive",
   "alloc",
 ] } # alloc is for no_std, derive is needed
 
 [dev-dependencies]
-burn = { version = "0.17.1", features = ["ndarray"] }
-image = { version = "0.24.9", features = ["png", "jpeg"] }
+burn = { version = "0.18.0", features = ["ndarray"] }
+image = { version = "0.25.6", features = ["png", "jpeg"] }

--- a/resnet-burn/Cargo.toml
+++ b/resnet-burn/Cargo.toml
@@ -17,10 +17,10 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 # Note: default-features = false is needed to disable std
-burn = { version = "0.17.1", default-features = false }
-burn-import = "0.17.1"
-dirs = "5.0.1"
-serde = { version = "1.0.192", default-features = false, features = [
+burn = { version = "0.18.0", default-features = false }
+burn-import = "0.18.0"
+dirs = "6.0.0"
+serde = { version = "1.0.219", default-features = false, features = [
     "derive",
     "alloc",
 ] } # alloc is for no_std, derive is needed

--- a/resnet-burn/examples/finetune/Cargo.toml
+++ b/resnet-burn/examples/finetune/Cargo.toml
@@ -16,10 +16,10 @@ resnet-burn = { path = "../../resnet", features = ["pretrained"] }
 burn = { workspace = true, features = ["train", "vision", "network"] }
 
 # Dataset files
-csv = "1.3.0"
-flate2 = "1.0.28"
-rand = { version = "0.8.5", default-features = false, features = [
+csv = "1.3.1"
+flate2 = "1.1.2"
+rand = { version = "0.9.2", default-features = false, features = [
     "std_rng",
 ] }
-serde = { version = "1.0.192", features = ["std", "derive"] }
-tar = "0.4.40"
+serde = { version = "1.0.219", features = ["std", "derive"] }
+tar = "0.4.44"

--- a/resnet-burn/examples/inference/Cargo.toml
+++ b/resnet-burn/examples/inference/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 [dependencies]
 resnet-burn = { path = "../../resnet", features = ["pretrained"] }
 burn = { workspace = true, features = ["ndarray"] }
-image = { version = "0.24.9", features = ["png", "jpeg"] }
+image = { version = "0.25.6", features = ["png", "jpeg"] }
 

--- a/squeezenet-burn/Cargo.toml
+++ b/squeezenet-burn/Cargo.toml
@@ -24,18 +24,18 @@ weights_file_dump = []
 [dependencies]
 
 # Note: default-features = false is needed to disable std
-burn = { version = "0.17.1", default-features = false }
+burn = { version = "0.18.0", default-features = false }
 
 # Used to load weights from a file
-serde = { version = "1.0.183", default-features = false, features = [
+serde = { version = "1.0.219", default-features = false, features = [
     "derive",
     "alloc",
 ] } # alloc is for no_std, derive is needed
 
 [dev-dependencies]
 # Used by the classify example
-burn = { version = "0.17.1", features = ["ndarray"]  }
-image = { version = "0.24.7", features = ["png", "jpeg"] }
+burn = { version = "0.18.0", features = ["ndarray"]  }
+image = { version = "0.25.6", features = ["png", "jpeg"] }
 
 [build-dependencies]
 # Used to generate code from ONNX model

--- a/yolox-burn/Cargo.toml
+++ b/yolox-burn/Cargo.toml
@@ -12,17 +12,17 @@ pretrained = ["burn/network", "std", "dep:dirs"]
 
 [dependencies]
 # Note: default-features = false is needed to disable std
-burn = { version = "0.17.1", default-features = false }
-burn-import = { version = "0.17.1" }
-itertools = { version = "0.12.1", default-features = false, features = [
+burn = { version = "0.18.0", default-features = false }
+burn-import = { version = "0.18.0" }
+itertools = { version = "0.14.0", default-features = false, features = [
     "use_alloc",
 ] }
-dirs = { version = "5.0.1", optional = true }
-serde = { version = "1.0.192", default-features = false, features = [
+dirs = { version = "6.0.0", optional = true }
+serde = { version = "1.0.219", default-features = false, features = [
     "derive",
     "alloc",
 ] } # alloc is for no_std, derive is needed
 
 [dev-dependencies]
-burn = { version = "0.17.1", features = ["ndarray"] }
-image = { version = "0.24.9", features = ["png", "jpeg"] }
+burn = { version = "0.18.0", features = ["ndarray"] }
+image = { version = "0.25.6", features = ["png", "jpeg"] }


### PR DESCRIPTION
## Summary
- update dependencies to current versions across all model crates
- set burn to version 0.18
- adjust supporting crates to latest compatible
- pin squeezenet's build dependency to burn-import 0.17 due to ONNX opset limits

## Testing
- `cargo build` and `cargo build --release` executed for `bert-burn`, `mobilenetv2-burn`, `squeezenet-burn`, and `resnet-burn`

------
https://chatgpt.com/codex/tasks/task_e_68866c1746148331b467ff7217b756fa